### PR TITLE
Fix : log_counts(annotations[dataset_type]['ClassName'])

### DIFF
--- a/open_images_downloader.py
+++ b/open_images_downloader.py
@@ -209,7 +209,7 @@ if __name__ == '__main__':
         print("  Image count:  {:d}".format(len(images[dataset_type])))
         print("  Bounding box count:  {:d}".format(len(annotations[dataset_type])))
         print("  Bounding box distribution: ")
-        log_counts(annotations[dataset_type]['ClassName'])
+        #log_counts(annotations[dataset_type]['ClassName'])
         #print("  Approximate image stats: ")
         #log_counts(annotations[dataset_type].drop_duplicates(["ImageID", "ClassName"])["ClassName"])
         print(" ")


### PR DESCRIPTION
log_count 에서 
'has no attribute' 
에러가 발생합니다. 

이 떄문에 코랩노트북 다음 셀에 필요한 sub_train_annotation_bbox.csv 가 생성되지 않습니다.

버전에 따라 문제가 생기는 것 같은데 주석처리 하는것이 좋을 것 같습니다. 